### PR TITLE
Support multiple style projects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ node_modules
 bower_components
 test_data
 data
+export

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,26 +20,24 @@ RUN wget -q -P /fonts https://github.com/aaronlidman/Toner-for-Tilemill/raw/mast
 
 ENV MAPNIK_FONT_PATH=/fonts
 
-RUN mkdir -p /usr/src/app
-COPY / /usr/src/app
-RUN cd /usr/src/app && npm install
-
+RUN mkdir -p /usr/src/app && mkdir -p /project
+WORKDIR /usr/src/app
 # only install minimal amount of tessera packages
 # be careful as some tessera packages collide with itself
-RUN npm install mbtiles \
-          tilelive-tmstyle \
-          tilelive-xray \
-          tilelive-http \
-          git+https://git@github.com/mojodna/node-tilejson.git\#always-xyz
+RUN npm install \
+    mbtiles@0.8.2  \
+    tilelive-tmstyle@0.4.2 \
+    tilelive-xray@0.2.0  \
+    tilelive-http@0.8.0
+
+COPY / /usr/src/app
+RUN npm install
 
 VOLUME /data
-ENV SOURCE_DATA_DIR=/data
-
-# destination of modified tm2 projects
-RUN mkdir -p /project
-ENV DEST_DATA_DIR=/project
+ENV SOURCE_DATA_DIR=/data \
+    DEST_DATA_DIR=/project \
+    PORT=80 \
+    MAPNIK_FONT_PATH=/fonts
 
 EXPOSE 80
-ENV PORT=80
-
 CMD ["/usr/src/app/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -6,13 +6,14 @@ set -o nounset
 readonly SOURCE_DATA_DIR=${SOURCE_DATA_DIR:-/data}
 readonly DEST_DATA_DIR=${DEST_DATA_DIR:-/project}
 readonly TESSERA_CONFIG="$DEST_DATA_DIR/config.json"
+
 readonly PORT=${PORT:-80}
 readonly CACHE_SIZE=${CACHE_SIZE:-10}
 readonly SOURCE_CACHE_SIZE=${SOURCE_CACHE_SIZE:-10}
 
 function serve_xray() {
     local mbtiles_file=$1
-    exec tessera "xray+mbtiles://$mbtiles_file" \
+    exec bin/tessera.js "xray+mbtiles://$mbtiles_file" \
         --PORT $PORT \
         --cache-size $CACHE_SIZE \
         --source-cache-size $SOURCE_CACHE_SIZE
@@ -78,7 +79,7 @@ function replace_sources() {
 }
 
 function serve_config() {
-    exec tessera -c "$TESSERA_CONFIG" \
+    exec bin/tessera.js -c "$TESSERA_CONFIG" \
         --PORT "$PORT" \
         --cache-size "$CACHE_SIZE" \
         --source-cache-size "$SOURCE_CACHE_SIZE"

--- a/run.sh
+++ b/run.sh
@@ -5,85 +5,111 @@ set -o nounset
 
 readonly SOURCE_DATA_DIR=${SOURCE_DATA_DIR:-/data}
 readonly DEST_DATA_DIR=${DEST_DATA_DIR:-/project}
+readonly TESSERA_CONFIG="$DEST_DATA_DIR/config.json"
 readonly PORT=${PORT:-80}
 readonly CACHE_SIZE=${CACHE_SIZE:-10}
 readonly SOURCE_CACHE_SIZE=${SOURCE_CACHE_SIZE:-10}
 
-# cd to app directory
-cd "$(dirname "$0")"
-
 function serve_xray() {
     local mbtiles_file=$1
-    exec node bin/tessera.js "xray+mbtiles://$mbtiles_file" \
+    exec tessera "xray+mbtiles://$mbtiles_file" \
         --PORT $PORT \
         --cache-size $CACHE_SIZE \
         --source-cache-size $SOURCE_CACHE_SIZE
 }
 
-# find first tm2 project
-if [ "$(ls -A $SOURCE_DATA_DIR)" ]; then
-    if [ -d "$SOURCE_DATA_DIR"/*.tm2 ]; then
-        for _PROJECT_DIR in "$SOURCE_DATA_DIR"/*.tm2; do
-            [ -d "${_PROJECT_DIR}" ] && PROJECT_DIR="${_PROJECT_DIR}" && break
-        done
-    else
-        MBTILES_FILE=""
-        for _MBTILES_FILE in "$SOURCE_DATA_DIR"/*.mbtiles; do
-            MBTILES_FILE="${_MBTILES_FILE}"
-            break
-        done
+function find_first_mbtiles() {
+    for mbtiles_file in "$SOURCE_DATA_DIR"/*.mbtiles; do
+        echo "${mbtiles_file}"
+        break
+    done
+}
 
-        if [ -f "$MBTILES_FILE" ]; then
-            echo "The mbtiles file is now served with X-Ray styles"
-            serve_xray "$MBTILES_FILE"
+function find_first_tm2() {
+    for tm2project in "$SOURCE_DATA_DIR"/*.tm2/; do
+        echo "${tm2project}"
+        break
+    done
+}
+
+function tessera_config_entry() {
+    local tm2project=$1
+    local serve_dir=${tm2project%.tm2}
+    local serve_path=${serve_dir##*/}
+    echo "\"/${serve_path}\": \"tmstyle://${tm2project}\"," >> "$TESSERA_CONFIG"
+    echo "Serving ${tm2project##*/} at $serve_path"
+}
+
+function create_tessera_config() {
+    local mbtiles_file=$1
+    rm -f "$TESSERA_CONFIG"
+    echo '{' >> "$TESSERA_CONFIG"
+    for tm2project in "$DEST_DATA_DIR"/*.tm2; do
+        tessera_config_entry "${tm2project}"
+    done
+
+    # Always serve the vector tile source
+    echo "\"/\": \"mbtiles://${mbtiles_file}\"" >> "$TESSERA_CONFIG"
+    echo '}' >> "$TESSERA_CONFIG"
+}
+
+function replace_sources() {
+    mbtiles_file=$1
+    local vectortiles_name=${mbtiles_file%.mbtiles}
+
+    for project_dir in "$SOURCE_DATA_DIR"/*.tm2; do
+        local project_name="${project_dir##*/}"
+        local project_config_file="${project_dir%%/}/project.yml"
+
+        # project config will be copied to new folder because we
+        # modify the source configuration of the style and don't want
+        # that to effect the original file
+        dest_project_dir="${DEST_DATA_DIR%%/}/$project_name"
+        local dest_project_config_file="${dest_project_dir%%/}/project.yml"
+        cp -rf "$project_dir" "$dest_project_dir"
+
+        # replace external vector tile sources with mbtiles source
+        # this allows developing rapidyl with an external source and then use the
+        # mbtiles for dependency free deployment
+        echo "Associating $vectortiles_name with $project_name"
+        replace_expr="s|source: \".*\"|source: \"mbtiles://$mbtiles_file\"|g"
+        sed -e "$replace_expr" $project_config_file > $dest_project_config_file
+    done
+}
+
+function serve_config() {
+    exec tessera -c "$TESSERA_CONFIG" \
+        --PORT "$PORT" \
+        --cache-size "$CACHE_SIZE" \
+        --source-cache-size "$SOURCE_CACHE_SIZE"
+}
+
+function serve() {
+    local mbtiles_file=$(find_first_mbtiles)
+    local tm2project=$(find_first_tm2)
+    if [ -f "$mbtiles_file" ]; then
+        echo "Using $mbtiles_file as vector tile source"
+        if [ -d "$tm2project" ]; then
+            replace_sources "$mbtiles_file"
+            create_tessera_config "$mbtiles_file"
+            serve_config
         else
-            echo "No tm2 projects found. Please add a tm2 project to your mounted folder."
-            exit 404
+            echo "The mbtiles file is now served with X-Ray styles"
+            serve_xray "$mbtiles_file"
         fi
+    else
+        echo "No MBTiles file found. Please add a .mbtiles file to your mounted folder."
+        exit 404
     fi
-else
-    echo "No tm2 projects found. Please mount the $SOURCE_DATA_DIR volume to a folder containing tm2 projects."
-    exit 404
-fi
-
-# find all tm2 projects but only the first project will be hosted for now
-PROJECT_NAME="${PROJECT_DIR##*/}"
-PROJECT_CONFIG_FILE="${PROJECT_DIR%%/}/project.yml"
-VECTORTILES_NAME="${PROJECT_NAME%.tm2}.mbtiles"
-MBTILES_FILE="${SOURCE_DATA_DIR%%/}/$VECTORTILES_NAME"
-
-echo "Found project ${PROJECT_NAME}"
-
-# project config will be copied to new folder because we
-# modify the source configuration of the style and don't want
-# that to effect the original file
-DEST_PROJECT_DIR="${DEST_DATA_DIR%%/}/$PROJECT_NAME"
-DEST_PROJECT_CONFIG_FILE="${DEST_PROJECT_DIR%%/}/project.yml"
-cp -rf "$PROJECT_DIR" "$DEST_PROJECT_DIR"
-
-# project.yml is single source of truth, therefore the mapnik
-# stylesheet is not necessary
-rm -f "${DEST_PROJECT_DIR%%/}/project.xml"
-
-# replace external vector tile sources with mbtiles source
-# this allows developing rapidyl with an external source and then use the
-# mbtiles for dependency free deployment
-if [ -f "$MBTILES_FILE" ]; then
-    echo "Associating $VECTORTILES_NAME with $PROJECT_NAME"
-    replace_expr="s|source: \".*\"|source: \"mbtiles://$MBTILES_FILE\"|g"
-    sed -e "$replace_expr" $PROJECT_CONFIG_FILE > $DEST_PROJECT_CONFIG_FILE
-else
-    echo "No mbtiles matching project $PROJECT_NAME found."
-    echo "Please name the mbtiles file the same as your style project."
-    exit 500
-fi
-
-function serve_style() {
-    local style_dir=$1
-    exec node bin/tessera.js "tmstyle://$style_dir" \
-        --PORT $PORT \
-        --cache-size $CACHE_SIZE \
-        --source-cache-size $SOURCE_CACHE_SIZE
 }
 
-serve_style "$DEST_PROJECT_DIR"
+function main() {
+    if [ "$(ls -A $SOURCE_DATA_DIR)" ]; then
+        serve
+    else
+        echo "No files found. Please mount the $SOURCE_DATA_DIR volume to a folder containing tm2 projects and mbtiles vector tile source."
+        exit 403
+    fi
+}
+
+main


### PR DESCRIPTION
Merging back from https://github.com/osm2vectortiles/osm2vectortiles/pull/84
- It is possible to have several style projects that all get associated with the same vector tiles
- Style project and MBTiles do no longer have to have the same name
- Dockerfile has been cleaned up a bit
