### PR TITLE
fix mapnik version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,6 @@ ENV MAPNIK_FONT_PATH=/fonts
 
 RUN mkdir -p /usr/src/app && mkdir -p /project
 WORKDIR /usr/src/app
-# only install minimal amount of tessera packages
-# be careful as some tessera packages collide with itself
-RUN npm install \
-    mbtiles@0.8.2  \
-    tilelive-tmstyle@0.4.2 \
-    tilelive-xray@0.2.0  \
-    tilelive-http@0.8.0
 
 COPY / /usr/src/app
 RUN npm install

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "https://github.com/klokantech/tileserver-tessera.git"
   },
   "dependencies": {
-    "async": "1.x",
     "abaculus": "1.x",
+    "async": "1.x",
     "cachecache": "1.x",
     "clone": "1.x",
     "cors": "2.x",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cors": "2.x",
     "debug": "2.x",
     "express": "4.x",
-    "handlebars": "4.",
+    "handlebars": "4.x",
     "morgan": "1.x",
     "nomnom": "1.x",
     "response-time": "2.x",

--- a/package.json
+++ b/package.json
@@ -14,20 +14,26 @@
     "url": "https://github.com/klokantech/tileserver-tessera.git"
   },
   "dependencies": {
-    "async": "^1.5.0",
-    "abaculus": "^1.2.1",
-    "cachecache": "^1.0.1",
-    "clone": "^1.0.2",
-    "cors": "^2.5.2",
-    "debug": "^2.1.3",
-    "express": "^4.10.3",
-    "handlebars": "^4.0.5",
-    "morgan": "^1.5.0",
-    "nomnom": "^1.8.1",
-    "response-time": "^2.2.0",
-    "sphericalmercator": "^1.0.2",
-    "tilelive": "^5.3.3",
-    "tilelive-cache": "^0.6.1",
-    "tilelive-modules": "^0.2.0"
+    "async": "1.x",
+    "abaculus": "1.x",
+    "cachecache": "1.x",
+    "clone": "1.x",
+    "cors": "2.x",
+    "debug": "2.x",
+    "express": "4.x",
+    "handlebars": "4.",
+    "morgan": "1.x",
+    "nomnom": "1.x",
+    "response-time": "2.x",
+    "sphericalmercator": "1.x",
+
+    "mbtiles": "0.8.2",
+    "tilelive": "5.12.2",
+    "tilelive-cache": "0.6.5",
+    "tilelive-http": "0.10.0",
+    "tilelive-modules": "0.2.1",
+    "tilelive-tmstyle": "0.6.0",
+    "tilelive-vector": "3.9.3",
+    "tilelive-xray": "0.2.0"
   }
 }


### PR DESCRIPTION
This PR does the following things:
1. Unifies the `npm install` and `package.json` installed modules into a single `package.json` one.
2. Updates the non-critical (above the blank line) libraries to `1.x` syntax instead of the `^1.2.3` syntax (just for better readability).
3. Specifies all the critical libraries to an exact patch version (below the blank line).

Built, tested and works fine.
